### PR TITLE
run in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+ARG UBUNTU_VERSION=18.04
+FROM nvidia/opengl:1.0-glvnd-runtime-ubuntu${UBUNTU_VERSION}
+
+ARG UBUNTU=bionic
+ARG ROS_DISTRO=melodic
+
+# ROS packages
+RUN apt-get update -qqy && DEBIAN_FRONTEND=noninteractive apt-get install -qqy gnupg2 && rm -rf /var/lib/apt/lists \
+ && echo "deb http://packages.ros.org/ros/ubuntu ${UBUNTU} main" > /etc/apt/sources.list.d/ros-latest.list \
+ && apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+
+# robotpkg packages
+ADD http://robotpkg.openrobots.org/packages/debian/robotpkg.key /
+RUN echo "deb [arch=amd64] http://robotpkg.openrobots.org/wip/packages/debian/pub ${UBUNTU} robotpkg" > /etc/apt/sources.list.d/robotpkg.list \
+ && echo "deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub ${UBUNTU} robotpkg" >> /etc/apt/sources.list.d/robotpkg.list \
+ && apt-key add /robotpkg.key
+
+# environment helpers
+ENV ROS_PREFIX=/opt/ros/${ROS_DISTRO} ROBOTPKG_BASE=/opt/openrobots
+# required environment variables
+ENV PYTHONPATH=${ROBOTPKG_BASE}/lib/python2.7/site-packages:${ROS_PREFIX}/lib/python2.7/dist-packages \
+    CMAKE_PREFIX_PATH=${ROBOTPKG_BASE}:${ROS_PREFIX} \
+    LD_LIBRARY_PATH=${ROBOTPKG_BASE}/lib/dynamic-graph-plugins \
+    QT_X11_NO_MITSHM=1
+
+# talos-integration-tests dependencies
+RUN apt-get update -qqy \
+ && DEBIAN_FRONTEND=noninteractive apt-get install -qqy \
+    git \
+    python-catkin-tools \
+    python-rosdep \
+    robotpkg-py27-talos-dev \
+ && rm -rf /var/lib/apt/lists
+
+# catkin workspace
+WORKDIR /ws
+RUN rosdep init \
+ && rosdep update \
+ && ${ROS_PREFIX}/bin/catkin_init_workspace
+
+# talos-integration-tests build
+ADD . /ws/src/talos_integration_tests
+RUN catkin build talos_integration_tests

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ of the algorithm and the weights used to in the simulator.
 In this specific context PID gains for position control are not the one provided by PAL-robotics.
 They are much more high and provide a more rigid behavior that was found experimentally closer to reality for some part
 of the robot. However, for now the flexibility in the hip found in real TALOS humanoid robots is not simulated.
-    
+
 # Setup
 ```
 mkdir -p test_ws/src
@@ -59,3 +59,22 @@ rostest talos_integration_tests test_online_walking.test
 ```
 The robot is supposed to walk forward 2.8 m and reached position [2.12,0.012,1.00]
 
+
+# Docker
+
+```
+xhost +local:
+# 18.04 / melodic
+docker build -t talos-integration-tests:18.04 .
+docker run --rm --net=host --runtime=nvidia -e DISPLAY -it talos-integration-tests:18.04
+# 16.04 / kinetic
+docker build -t talos-integration-tests:16.04 --build-arg UBUNTU_VERSION=16.04 --build-arg UBUNTU=xenial --build-arg ROS_DISTRO=kinetic .
+docker run --rm --net=host --runtime=nvidia -e DISPLAY -it talos-integration-tests:16.04
+```
+
+Once in the container:
+```
+source devel/setup.bash
+rostest talos_integration_tests test_kine.test
+rostest talos_integration_tests test_sot_talos_balance.test
+```


### PR DESCRIPTION
Hi,

Here is a dockerfile that can be built on 16.04 and  18.04 to run all tests. It installs all depedencies from the binary packages. Another version that build everything will be pushed soon to the gepetto buildfarm.