### PR TITLE
[Docker] configure catkin to install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,3 +44,6 @@ RUN rosdep init \
 ADD . /ws/src/talos_integration_tests
 RUN catkin config --install \
  && catkin build talos_integration_tests
+
+ENTRYPOINT ["/ws/src/talos_integration_tests/entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,5 @@ RUN rosdep init \
 
 # talos-integration-tests build
 ADD . /ws/src/talos_integration_tests
-RUN catkin build talos_integration_tests
+RUN catkin config --install \
+ && catkin build talos_integration_tests

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ docker run --rm --net=host --runtime=nvidia -e DISPLAY -it talos-integration-tes
 
 Once in the container:
 ```
-source install/setup.bash
 rostest talos_integration_tests test_kine.test
 rostest talos_integration_tests test_sot_talos_balance.test
 ```

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ docker run --rm --net=host --runtime=nvidia -e DISPLAY -it talos-integration-tes
 
 Once in the container:
 ```
-source devel/setup.bash
+source install/setup.bash
 rostest talos_integration_tests test_kine.test
 rostest talos_integration_tests test_sot_talos_balance.test
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+source /ws/install/setup.bash
+exec "$@"


### PR DESCRIPTION
follows #11 

While here, avoid docker build failures because of gpg keyservers, by downloading keys in http.